### PR TITLE
camera: Fix calculation of available RAM

### DIFF
--- a/QCamera2/HAL/QCameraParameters.cpp
+++ b/QCamera2/HAL/QCameraParameters.cpp
@@ -5749,9 +5749,11 @@ int32_t QCameraParameters::initDefaultParameters()
     struct sysinfo info;
     sysinfo(&info);
 
-    LOGH("totalram = %ld, freeram = %ld ", info.totalram,
-        info.freeram);
-    if (info.totalram > TOTAL_RAM_SIZE_512MB) {
+    uint64_t totalram = info.totalram * info.mem_unit;
+    uint64_t freeram = info.freeram * info.mem_unit;
+
+    LOGH("totalram = %ld, freeram = %ld ", totalram, freeram);
+    if (totalram > TOTAL_RAM_SIZE_512MB) {
         set(KEY_QC_ZSL_HDR_SUPPORTED, VALUE_TRUE);
     } else {
         m_bIsLowMemoryDevice = true;


### PR DESCRIPTION
- The compat version of the sysinfo struct (camera stack is all 32-bit)
  defines all members with 32-bit unsigned ints. If there is an
  overflow, the mem_unit field will be set with the divisor that
  was used after scaling down totalram/freeram. With the current
  version of the kernel syscall code, this ends up being either
  1 (if it fit in 32-bits) or PAGE_SIZE (4096 in our case).
- Since the OP3 has 6GB of RAM, we're overflowing what an unsigned
  32-bit int can hold, and the value is reported divided by 4096.
  The code from Qualcomm here does not do the multiplication
  and thus ZSL+HDR is disabled, along with a few other nice features
  such as Longshot.
