### PR TITLE
Update to prevent dots pattern in RAW pictures

### DIFF
--- a/QCamera2/HAL3/QCamera3Channel.cpp
+++ b/QCamera2/HAL3/QCamera3Channel.cpp
@@ -1585,8 +1585,7 @@ int32_t QCamera3ProcessingChannel::translateStreamTypeAndFormat(camera3_stream_t
         case HAL_PIXEL_FORMAT_RAW16:
         case HAL_PIXEL_FORMAT_RAW10:
             streamType = CAM_STREAM_TYPE_RAW;
-            streamFormat = getStreamDefaultFormat(CAM_STREAM_TYPE_RAW,
-                    stream->width, stream->height);
+            streamFormat = CAM_FORMAT_BAYER_IDEAL_RAW_MIPI_10BPP_GBRG;
             break;
         case HAL_PIXEL_FORMAT_RAW8:
             streamType = CAM_STREAM_TYPE_RAW;


### PR DESCRIPTION
I think I found out a RAW stream without PDAF pixels in order to avoid dots pattern issue in Oneplus 5 and Oneplus 5T in RAW pictures taken with Camera2 API RAW.

The current issue is that Camera2 API RAW redirects to a CAMIF_RAW stream who contains the dots pattern issue.
To get ride of this issue, we need to get a IDEAL_RAW stream. We use MIPI because is the RAW current standards.
You just have to ensure that CAM_FORMAT_BAYER_IDEAL_RAW_MIPI_10BPP_GBRG stream returns a working stream because the only working IDEAL_RAW stream working are CAM_FORMAT_BAYER_IDEAL_RAW_QCOM_10BPP_####, who is use by the Oneplus Camera app. I tested it but I was forced to use "RAW_SENSOR" (RAW 16 BPP) from Camera2 API to work and the final pictures was pinkish with a lot of bad signal informations, probably because of the buggy method "convertLegacyToRaw16".

I reverse-engineered camera.msm8998.so to test all of this.

@desuvinodkumar